### PR TITLE
Add Utility To Remove Reference Of Disabled Components

### DIFF
--- a/Assets/Scripts/Enemy/State/Attack.cs
+++ b/Assets/Scripts/Enemy/State/Attack.cs
@@ -61,5 +61,7 @@ public class Attack : State
             _prevState = idle;
         else if (TryGetComponent<Patrol>(out Patrol patrol))
             _prevState = patrol;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _prevState);
     }
 }

--- a/Assets/Scripts/Enemy/State/Chase.cs
+++ b/Assets/Scripts/Enemy/State/Chase.cs
@@ -53,6 +53,8 @@ public class Chase : State
     {
         if (TryGetComponent<Attack>(out Attack attack))
             _attackState = attack;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _attackState);
     }
 
     private void TryGetPrevState()
@@ -63,5 +65,7 @@ public class Chase : State
             _prevState = patrol;
         else
             _playerDistanceToChaseState = Mathf.Infinity;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _prevState);
     }
 }

--- a/Assets/Scripts/Enemy/State/Idle.cs
+++ b/Assets/Scripts/Enemy/State/Idle.cs
@@ -59,6 +59,8 @@ public class Idle : State
     {
         if (TryGetComponent<Patrol>(out Patrol patrol))
             _patrolState = patrol;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _patrolState);
     }
 
     private void TryGetNextState()
@@ -67,6 +69,8 @@ public class Idle : State
             _nextState = chase;
         else if (TryGetComponent<Attack>(out Attack attack))
             _nextState = attack;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _nextState);
     }
 
     private void LateUpdate()

--- a/Assets/Scripts/Enemy/State/Patrol.cs
+++ b/Assets/Scripts/Enemy/State/Patrol.cs
@@ -71,6 +71,8 @@ public class Patrol : State
     {
         if (TryGetComponent<Idle>(out Idle idle))
             _idleState = idle;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _idleState);
     }
 
     private void TryGetNextState()
@@ -79,6 +81,8 @@ public class Patrol : State
             _nextState = chase;
         else if (TryGetComponent<Attack>(out Attack attack))
             _nextState = attack;
+
+        Utilities.RemoveReferenceOfDisabledComponent<State>(ref _nextState);
     }
 
     private void LateUpdate()

--- a/Assets/Scripts/Other/Utilities/Utililties.cs
+++ b/Assets/Scripts/Other/Utilities/Utililties.cs
@@ -6,4 +6,12 @@ public static class Utilities
     {
         component = (gameObject.GetComponent<T>()) ? gameObject.GetComponent<T>() : gameObject.AddComponent<T>();
     }
+
+    public static void RemoveReferenceOfDisabledComponent<T>(ref T reference) where T : MonoBehaviour
+    {
+        if (reference == null) return;
+
+        if (!reference.enabled)
+            reference = null;
+    }
 }


### PR DESCRIPTION
Add utility tool for testing or error catching/handling.

Removing references of disabled components also allows for easier testing w/o the need to remove components manually.