### PR TITLE
Enemy Culling

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -109,6 +109,11 @@ public abstract class EnemyBase : StateMachine, IDamageable
         this.enabled = true;
     }
 
+    private void OnBecameInvisible()
+    {
+        this.enabled = false;
+    }
+
     private void InitializeState()
     {
         if (TryGetComponent<Idle>(out Idle idle))

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -104,6 +104,11 @@ public abstract class EnemyBase : StateMachine, IDamageable
         CheckForPlayerCollision();
     }
 
+    private void OnBecameVisible()
+    {
+        this.enabled = true;
+    }
+
     private void InitializeState()
     {
         if (TryGetComponent<Idle>(out Idle idle))

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -19,6 +19,7 @@ public abstract class EnemyBase : StateMachine, IDamageable
 
     private int _instanceID = 0;
     private bool _isFacingRight = true;
+    private Vector2 _basePosition;
     private Collider2D[] _playerCollider = new Collider2D[1];
     private SpriteController _spriteController;
 
@@ -79,6 +80,7 @@ public abstract class EnemyBase : StateMachine, IDamageable
 
     private void Awake()
     {
+        _basePosition = transform.position;
         _health = new Health(_maxHealth, _healthBar);
         _instanceID = gameObject.GetInstanceID();
 
@@ -112,6 +114,7 @@ public abstract class EnemyBase : StateMachine, IDamageable
 
     private void OnBecameInvisible()
     {
+        transform.position = _basePosition;
         this.enabled = false;
     }
 

--- a/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/Assets/Scripts/Enemy/EnemyBase.cs
@@ -87,6 +87,7 @@ public abstract class EnemyBase : StateMachine, IDamageable
         _rb2D = GetComponent<Rigidbody2D>();
 
         InitializeState();
+        this.enabled = false;
     }
 
     protected override void Update()

--- a/Assets/Scripts/Enemy/State/Idle.cs
+++ b/Assets/Scripts/Enemy/State/Idle.cs
@@ -55,6 +55,11 @@ public class Idle : State
         TryGetNextState();
     }
 
+    private void OnBecameInvisible()
+    {
+        _currentTime = 0;
+    }
+
     private void TryGetPatrolState()
     {
         if (TryGetComponent<Patrol>(out Patrol patrol))

--- a/Assets/Scripts/Enemy/State/Patrol.cs
+++ b/Assets/Scripts/Enemy/State/Patrol.cs
@@ -67,6 +67,11 @@ public class Patrol : State
         TryGetNextState();
     }
 
+    private void OnBecameInvisible()
+    {
+        _currentWayPoint = 0;
+    }
+
     private void TryGetIdleState()
     {
         if (TryGetComponent<Idle>(out Idle idle))


### PR DESCRIPTION
- Enable/Disable Enemy logic depending on whether the renderer is visible to the camera.
- Enemy logic should only run when Enemy is visible. 
- Reset Enemy when outside of camera view. (e.g. Reset Enemy Position, Reset Patrol Waypoint, Reset Idle Timer)