### PR TITLE
Rewrite Instant Death

### DIFF
--- a/Assets/Prefabs/Game/Player.prefab
+++ b/Assets/Prefabs/Game/Player.prefab
@@ -545,7 +545,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 6717973789561704259}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 6200000, guid: d0056c69a7fd25f439cdb7b26ed3392a, type: 2}
+  m_Material: {fileID: 6200000, guid: e33261a5c40f21443afd2d745c01efdb, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Obstacles/Pit.prefab
+++ b/Assets/Prefabs/Obstacles/Pit.prefab
@@ -43,7 +43,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.90758955, y: -0.20981905}

--- a/Assets/Prefabs/Obstacles/Spikes.prefab
+++ b/Assets/Prefabs/Obstacles/Spikes.prefab
@@ -96,7 +96,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/Assets/Scripts/Gameplay/InstantKillObstacles.cs
+++ b/Assets/Scripts/Gameplay/InstantKillObstacles.cs
@@ -7,5 +7,6 @@ public class InstantKillObstacles : MonoBehaviour
 {
     private void Awake()
     {
+        GetComponent<BoxCollider2D>().isTrigger = false;
     }
 }

--- a/Assets/Scripts/Gameplay/InstantKillObstacles.cs
+++ b/Assets/Scripts/Gameplay/InstantKillObstacles.cs
@@ -7,14 +7,5 @@ public class InstantKillObstacles : MonoBehaviour
 {
     private void Awake()
     {
-        GetComponent<BoxCollider2D>().isTrigger = true;
-    }
-
-    private void OnTriggerEnter2D(Collider2D collision)
-    {
-        if(collision.TryGetComponent<Player>(out Player player))
-        {
-            player.TakeDamage(player.MaxHealth);
-        }
     }
 }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -32,13 +32,14 @@ public class Player : MonoBehaviour
 
     public void TakeDamage(int value, int knockBackDirection = 0)
     {
-        if (_isHurt || _spriteController.IsFlashing) return;
+        if (_isHurt || _spriteController.IsFlashing || _isDead) return;
 
         _health.CurrentHealth -= value;
         _isHurt = true;
 
         if (_health.CurrentHealth <= 0)
         {
+            _isDead = true;
             OnPlayerDeath?.Invoke(true);
             return;
         }
@@ -70,6 +71,14 @@ public class Player : MonoBehaviour
         if (GameController.Instance == null) return;
 
         GameController.Instance.OnPauseEvent -= DisablePlayerActions;
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (!collision.gameObject.GetComponent<InstantKillObstacles>() || _isDead) return;
+
+        _isDead = true;
+        OnPlayerDeath?.Invoke(true);
     }
 
     private void ApplyKnockBack(int knockBackDirection = 0)

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -28,8 +28,6 @@ public class Player : MonoBehaviour
     public delegate void PlayerDeath(bool isPlayerDead);
     public event PlayerDeath OnPlayerDeath;
 
-    public int MaxHealth { get { return _maxHealth; } }
-
 
     public void TakeDamage(int value, int knockBackDirection = 0)
     {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -24,6 +24,7 @@ public class Player : MonoBehaviour
     private Health _health;
 
     private bool _isHurt = false;
+    private bool _isDead = false;
 
     public delegate void PlayerDeath(bool isPlayerDead);
     public event PlayerDeath OnPlayerDeath;


### PR DESCRIPTION
Rewrite Instant Death mechanic to invoke player death on collision with obstacles, regardless of player invulnerability. 