### PR TITLE
Proximity Attack Hitbox Initialization

### DIFF
--- a/Assets/Scripts/Player/AttackObjectController.cs
+++ b/Assets/Scripts/Player/AttackObjectController.cs
@@ -22,6 +22,8 @@ public class AttackObjectController : MonoBehaviour
 
     private void Awake()
     {
+        GetComponent<Collider2D>().isTrigger = true;
+        
         _baseScale = transform.localScale;
     }
 

--- a/Assets/Scripts/Player/AttackObjectController.cs
+++ b/Assets/Scripts/Player/AttackObjectController.cs
@@ -25,6 +25,10 @@ public class AttackObjectController : MonoBehaviour
         GetComponent<Collider2D>().isTrigger = true;
         
         _baseScale = transform.localScale;
+
+        HitboxScaleResetCounter = 1;
+        AnimationSpeedMultiplier = 1f;
+
     }
 
     private void OnEnable()

--- a/Assets/Scripts/Player/AttackObjectController.cs
+++ b/Assets/Scripts/Player/AttackObjectController.cs
@@ -29,6 +29,7 @@ public class AttackObjectController : MonoBehaviour
         HitboxScaleResetCounter = 1;
         AnimationSpeedMultiplier = 1f;
 
+        gameObject.SetActive(false);
     }
 
     private void OnEnable()


### PR DESCRIPTION
Ensures Proximity Attack Hitbox is set-up properly at the start of the game, regardless of editor settings